### PR TITLE
Add redirect from wiidx to wiiplus

### DIFF
--- a/wiidx/index.html
+++ b/wiidx/index.html
@@ -1,0 +1,1 @@
+<meta http-equiv="refresh" content="0; URL='https://newerteam.com/wiiplus/'" />


### PR DESCRIPTION
A lot of links and comments still point to newerteam.com/wiidx and have not been changed to newerteam.com/wiiplus-- this redirect should send people to the expected page instead of a 404.